### PR TITLE
Fix v0.6.1 update verification and QMC task recovery

### DIFF
--- a/backend/app_update.go
+++ b/backend/app_update.go
@@ -100,7 +100,7 @@ func (a *App) DownloadAndInstallUpdate(tagName string) (UpdateInstallResult, err
 
 	ctx, cancel := context.WithTimeout(a.ctx, updateDownloadTimeout)
 	defer cancel()
-	if err := downloadOfficialReleaseAsset(ctx, checksum, checksumPath, maxUpdateChecksumBytes); err != nil {
+	if err := downloadOfficialReleaseAssetFromGitHub(ctx, checksum, checksumPath, maxUpdateChecksumBytes); err != nil {
 		return UpdateInstallResult{}, fmt.Errorf("下载更新校验文件失败: %w", err)
 	}
 	checksumData, err := os.ReadFile(checksumPath)
@@ -217,18 +217,34 @@ func downloadOfficialReleaseAsset(ctx context.Context, asset handler.ReleaseAsse
 	return fmt.Errorf("GitHub 与备用下载地址均失败: %w", errors.Join(failures...))
 }
 
+func downloadOfficialReleaseAssetFromGitHub(ctx context.Context, asset handler.ReleaseAsset, destination string, maximumBytes int64) error {
+	// The checksum is the trust anchor for a proxied installer and must never use
+	// the same fallback proxy or follow a redirect to it.
+	if err := validateOfficialReleaseAssetURL(asset.DownloadURL); err != nil {
+		return err
+	}
+	if err := downloadReleaseAssetFromURL(ctx, asset.DownloadURL, destination, maximumBytes); err != nil {
+		return fmt.Errorf("GitHub: %w", err)
+	}
+	return nil
+}
+
 func downloadReleaseAssetFromURL(ctx context.Context, downloadURL string, destination string, maximumBytes int64) error {
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
 	if err != nil {
 		return err
 	}
 	request.Header.Set("User-Agent", "Kugo-Music-Converter-Updater")
+	allowProxyRedirect := strings.EqualFold(request.URL.Hostname(), "gh.h233.eu.org")
 	client := &http.Client{
-		CheckRedirect: func(request *http.Request, via []*http.Request) error {
+		CheckRedirect: func(redirectRequest *http.Request, via []*http.Request) error {
 			if len(via) >= 10 {
 				return errors.New("更新下载重定向次数过多")
 			}
-			host := strings.ToLower(request.URL.Hostname())
+			host := strings.ToLower(redirectRequest.URL.Hostname())
+			if host == "gh.h233.eu.org" && !allowProxyRedirect {
+				return errors.New("官方更新下载不允许重定向到备用地址")
+			}
 			if host != "github.com" && host != "gh.h233.eu.org" && !strings.HasSuffix(host, ".githubusercontent.com") {
 				return errors.New("更新下载被重定向到未允许的地址")
 			}

--- a/backend/app_update.go
+++ b/backend/app_update.go
@@ -72,7 +72,7 @@ func (a *App) DownloadAndInstallUpdate(tagName string) (UpdateInstallResult, err
 		Type:  wailsruntime.QuestionDialog,
 		Title: "下载并安装更新",
 		Message: fmt.Sprintf(
-			"将优先从项目官方 GitHub Release 下载 %s（约 %s）；直连失败时使用 gh.h233.eu.org 转发同一官方地址。SHA-256 校验通过后才会启动安装器。\n\n安装器启动后应用将退出，请先保存其他工作。",
+			"程序会先从项目官方 GitHub Release 获取 SHA-256 校验文件，再下载 %s（约 %s）。安装器直连失败时可使用 gh.h233.eu.org 转发同一官方地址；如果无法从 GitHub 获取校验文件，自动更新将停止。校验通过后才会启动安装器。\n\n安装器启动后应用将退出，请先保存其他工作。",
 			installer.Name,
 			formatCacheBytes(installer.Size),
 		),

--- a/backend/app_update_test.go
+++ b/backend/app_update_test.go
@@ -136,6 +136,45 @@ func TestDownloadOfficialReleaseAssetStopsAfterGitHubSuccess(t *testing.T) {
 	}
 }
 
+func TestDownloadOfficialReleaseAssetFromGitHubNeverUsesFallback(t *testing.T) {
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	attemptedURLs := make([]string, 0, 1)
+	http.DefaultTransport = roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		attemptedURLs = append(attemptedURLs, request.URL.String())
+		status := http.StatusFound
+		body := ""
+		header := make(http.Header)
+		header.Set("Location", updateDownloadProxyBase+officialAssetURL("Kugo-Music-Converter-v0.6.0-windows-amd64-setup.exe.sha256"))
+		if request.URL.Hostname() == "gh.h233.eu.org" {
+			status = http.StatusOK
+			body = "forged checksum"
+		}
+		return &http.Response{
+			StatusCode:    status,
+			Body:          io.NopCloser(strings.NewReader(body)),
+			ContentLength: int64(len(body)),
+			Header:        header,
+			Request:       request,
+		}, nil
+	})
+
+	assetName := "Kugo-Music-Converter-v0.6.0-windows-amd64-setup.exe.sha256"
+	destination := filepath.Join(t.TempDir(), assetName)
+	err := downloadOfficialReleaseAssetFromGitHub(t.Context(), handler.ReleaseAsset{
+		Name:        assetName,
+		DownloadURL: officialAssetURL(assetName),
+		Size:        100,
+	}, destination, 1024)
+	if err == nil {
+		t.Fatal("GitHub failure was accepted for the checksum asset")
+	}
+	if len(attemptedURLs) != 1 || attemptedURLs[0] != officialAssetURL(assetName) {
+		t.Fatalf("attempted URLs = %#v, want only official GitHub", attemptedURLs)
+	}
+}
+
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {

--- a/backend/internal/handler/convert_api.go
+++ b/backend/internal/handler/convert_api.go
@@ -320,12 +320,18 @@ func hasKGG(items []service.BatchItem) bool {
 type qmcBatchFuture struct {
 	done chan struct{}
 	keys map[string]qmcBatchKey
+	err  error
 }
 
 func startQMCBatchFuture(ctx context.Context, handler *ConvertHandler, items []service.BatchItem) *qmcBatchFuture {
 	future := &qmcBatchFuture{done: make(chan struct{})}
 	go func() {
-		defer close(future.done)
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				future.err = NewAppError(ErrQMCKeyUnavailable, fmt.Sprintf("QQ 音乐取钥任务异常 (%T)", recovered), nil)
+			}
+			close(future.done)
+		}()
 		future.keys = handler.resolveQMCBatchKeys(ctx, items)
 	}()
 	return future
@@ -339,7 +345,7 @@ func (f *qmcBatchFuture) wait(ctx context.Context) (map[string]qmcBatchKey, erro
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	case <-f.done:
-		return f.keys, nil
+		return f.keys, f.err
 	}
 }
 
@@ -379,7 +385,10 @@ func (h *ConvertHandler) convertSingleItem(ctx context.Context, item service.Bat
 		}
 		qmcKeys, waitErr := qmcFuture.wait(ctx)
 		if waitErr != nil {
-			return "", NewAppError(ErrCancelled, "QQ 音乐取钥已取消", waitErr)
+			if errors.Is(waitErr, context.Canceled) || errors.Is(waitErr, context.DeadlineExceeded) {
+				return "", NewAppError(ErrCancelled, "QQ 音乐取钥已取消", waitErr)
+			}
+			return "", waitErr
 		}
 		if key, ok := qmcKeys[item.Path]; ok {
 			if key.err != nil {

--- a/backend/internal/handler/convert_qmc_async_test.go
+++ b/backend/internal/handler/convert_qmc_async_test.go
@@ -3,8 +3,10 @@ package handler
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -17,6 +19,16 @@ import (
 type blockingQMCResolver struct {
 	started chan struct{}
 	release chan struct{}
+}
+
+type panickingQMCResolver struct{}
+
+func (panickingQMCResolver) Resolve(context.Context, qmckey.Resource) (string, error) {
+	panic("sensitive-auth-token")
+}
+
+func (panickingQMCResolver) ResolveBatch(context.Context, []qmckey.Resource) []qmckey.BatchResult {
+	panic("sensitive-auth-token")
 }
 
 func (r *blockingQMCResolver) Resolve(ctx context.Context, resource qmckey.Resource) (string, error) {
@@ -117,5 +129,31 @@ func TestExecuteBatchDoesNotBlockOfflineItemsOnQMCKeyFetch(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("batch did not finish after resolver release")
+	}
+}
+
+func TestQMCBatchFutureRecoversResolverPanic(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "modern.mgg")
+	data := append([]byte("encrypted"), testMusicExFooter(t, "ModernMID", "O8M000Modern.mgg")...)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	handler := &ConvertHandler{qmcKeyResolver: panickingQMCResolver{}}
+	future := startQMCBatchFuture(context.Background(), handler, []service.BatchItem{{
+		Path: path,
+		Name: filepath.Base(path),
+	}})
+	_, err := future.wait(context.Background())
+	if err == nil {
+		t.Fatal("resolver panic was not returned as an error")
+	}
+	var appErr *AppError
+	if !errors.As(err, &appErr) || appErr.Code != ErrQMCKeyUnavailable {
+		t.Fatalf("panic error = %#v, want %s", err, ErrQMCKeyUnavailable)
+	}
+	if strings.Contains(err.Error(), "sensitive-auth-token") {
+		t.Fatalf("panic value leaked into error: %v", err)
 	}
 }


### PR DESCRIPTION
## 修复内容\n\n- SHA-256 校验文件现在只允许从项目官方 GitHub Release 地址下载，也拒绝从 GitHub 重定向到备用代理；安装器本身仍保留 GitHub 直连失败后的备用下载能力。\n- QMC 异步批量取钥任务增加 panic 恢复，将异常收敛为 ERR_QMC_KEY_UNAVAILABLE，避免桌面进程退出且不泄漏 panic 内容。\n\n## 验证\n\n- 新增官方校验文件拒绝代理和代理重定向的回归测试。\n- 新增 QMC resolver panic 恢复与敏感内容不泄漏测试。\n- go test ./...、untimebundle,release 标签测试、go vet ./...、go build ./... 和前端 8 项测试通过。\n- v0.6.1 四项 Windows 资产重新构建，版本、内嵌运行时、未签名状态和 SHA-256 门禁通过。\n\n本 PR 不修改版本号、UI、转换格式、Release 正文或其他功能。